### PR TITLE
Add MVP scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL=postgresql://postgres:postgres@db:5432/postgres
+LISTING_CONTEXT_URL=http://listing_context:8000
+SCANNER_CONTEXT_URL=http://scanner_context:8001
+DMCA_CONTEXT_URL=http://dmca_context:8002

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # ClaimBot
-Automated agent for filing and tracking DMCA claims.
+
+Minimal MVP for Etsy DMCA protection. This repository contains a Next.js frontend and three FastAPI services managed via Docker Compose.
+
+## Development
+
+```
+docker-compose up --build
+```
+
+The services expose the following ports:
+
+- **frontend**: http://localhost:3000
+- **ListingContext**: http://localhost:8000
+- **ScannerContext**: http://localhost:8001
+- **DMCAContext**: http://localhost:8002
+
+Configure environment variables in `.env` if needed.

--- a/backend/dmca_context/Dockerfile
+++ b/backend/dmca_context/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8002"]

--- a/backend/dmca_context/app/main.py
+++ b/backend/dmca_context/app/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import requests
+import os
+
+LISTING_CONTEXT_URL = os.getenv('LISTING_CONTEXT_URL', 'http://listing_context:8000')
+
+app = FastAPI(title="DMCAContext")
+
+class GenerateRequest(BaseModel):
+    violation_id: str
+
+@app.post('/generate')
+def generate(req: GenerateRequest):
+    # Placeholder DMCA generation
+    notice = f"DMCA notice for violation {req.violation_id}"
+    return {"notice": notice}

--- a/backend/dmca_context/requirements.txt
+++ b/backend/dmca_context/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+requests
+pydantic

--- a/backend/listing_context/Dockerfile
+++ b/backend/listing_context/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/listing_context/app/database.py
+++ b/backend/listing_context/app/database.py
@@ -1,0 +1,9 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+import os
+
+DATABASE_URL = os.getenv('DATABASE_URL', 'postgresql://postgres:postgres@db:5432/postgres')
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/backend/listing_context/app/fingerprint.py
+++ b/backend/listing_context/app/fingerprint.py
@@ -1,0 +1,27 @@
+import requests
+import numpy as np
+from scipy.spatial.distance import cosine
+
+class FingerprintModel:
+    base_url = 'http://localhost:11434'
+
+    def compute_image_hash(self, image_url: str) -> str:
+        # Placeholder: return dummy hash
+        return 'hash'
+
+    def compute_text_embedding(self, text: str) -> list[float]:
+        resp = requests.post(f'{self.base_url}/api/generate', json={"model": "llama3", "prompt": text})
+        embedding = [float(x) for x in range(10)]  # dummy embedding
+        return embedding
+
+    def compare_embeddings(self, vec1: list[float], vec2: list[float]) -> float:
+        if not vec1 or not vec2:
+            return 0.0
+        v1, v2 = np.array(vec1), np.array(vec2)
+        return 1 - cosine(v1, v2)
+
+    def compare_image_hashes(self, hash1: str, hash2: str) -> float:
+        if len(hash1) != len(hash2):
+            return 0.0
+        distance = sum(ch1 != ch2 for ch1, ch2 in zip(hash1, hash2))
+        return 1 - distance / len(hash1)

--- a/backend/listing_context/app/main.py
+++ b/backend/listing_context/app/main.py
@@ -1,0 +1,38 @@
+from fastapi import FastAPI, HTTPException, Depends
+from sqlalchemy.orm import Session
+from .database import Base, engine, SessionLocal
+from . import models, schemas, fingerprint
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="ListingContext")
+model = fingerprint.FingerprintModel()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@app.post('/listings', response_model=schemas.Listing)
+def create_listing(payload: schemas.ListingCreate, db: Session = Depends(get_db)):
+    image_hash = model.compute_image_hash(payload.image_url or '')
+    embedding = model.compute_text_embedding(payload.description or '')
+    listing = models.ListingModel(
+        shop_url=payload.shop_url,
+        title=payload.title,
+        description=payload.description,
+        image_url=payload.image_url,
+        image_hash=image_hash,
+        text_embedding=embedding
+    )
+    db.add(listing)
+    db.commit()
+    db.refresh(listing)
+    return listing
+
+@app.get('/listings')
+def read_listings(shop_url: str, db: Session = Depends(get_db)):
+    listings = db.query(models.ListingModel).filter_by(shop_url=shop_url).all()
+    return listings

--- a/backend/listing_context/app/models.py
+++ b/backend/listing_context/app/models.py
@@ -1,0 +1,28 @@
+from sqlalchemy import Column, String, Float, Boolean, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID, ARRAY
+from datetime import datetime
+import uuid
+
+from .database import Base
+
+class ListingModel(Base):
+    __tablename__ = 'listings'
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    shop_url = Column(String, nullable=False)
+    title = Column(String, nullable=False)
+    description = Column(String)
+    image_url = Column(String)
+    image_hash = Column(String)
+    text_embedding = Column(ARRAY(Float))
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+class ViolationModel(Base):
+    __tablename__ = 'violations'
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    original_listing_id = Column(UUID(as_uuid=True), ForeignKey('listings.id'))
+    suspect_url = Column(String, nullable=False)
+    suspect_image_url = Column(String)
+    similarity_score = Column(Float)
+    platform = Column(String, default='etsy')
+    reported = Column(Boolean, default=False)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/backend/listing_context/app/schemas.py
+++ b/backend/listing_context/app/schemas.py
@@ -1,0 +1,32 @@
+from pydantic import BaseModel, Field
+from typing import List
+from uuid import UUID
+from datetime import datetime
+
+class ListingCreate(BaseModel):
+    shop_url: str
+    title: str
+    description: str | None = None
+    image_url: str | None = None
+
+class Listing(ListingCreate):
+    id: UUID
+    image_hash: str | None = None
+    text_embedding: List[float] | None = None
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+class Violation(BaseModel):
+    id: UUID
+    original_listing_id: UUID
+    suspect_url: str
+    suspect_image_url: str | None
+    similarity_score: float
+    platform: str
+    reported: bool
+    created_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/backend/listing_context/requirements.txt
+++ b/backend/listing_context/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+SQLAlchemy
+psycopg2-binary
+pydantic
+requests
+numpy
+scipy

--- a/backend/scanner_context/Dockerfile
+++ b/backend/scanner_context/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/backend/scanner_context/app/main.py
+++ b/backend/scanner_context/app/main.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI, Depends
+import requests
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from pydantic import BaseModel
+import os
+
+DATABASE_URL = os.getenv('DATABASE_URL', 'postgresql://postgres:postgres@db:5432/postgres')
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine)
+
+app = FastAPI(title="ScannerContext")
+
+LISTING_CONTEXT_URL = os.getenv('LISTING_CONTEXT_URL', 'http://listing_context:8000')
+
+class ScanRequest(BaseModel):
+    shop_url: str
+
+@app.post('/scan')
+def scan(req: ScanRequest):
+    resp = requests.get(f'{LISTING_CONTEXT_URL}/listings', params={'shop_url': req.shop_url})
+    listings = resp.json()
+    # TODO: simulate scraping suspect listings
+    violations = []
+    for listing in listings:
+        violations.append({'original_listing_id': listing['id'], 'suspect_url': 'https://example.com', 'similarity_score': 0.9})
+    return {'violations': violations}

--- a/backend/scanner_context/requirements.txt
+++ b/backend/scanner_context/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+SQLAlchemy
+requests
+pydantic
+numpy
+scipy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '3.8'
+services:
+  frontend:
+    build: ./frontend
+    ports:
+      - '3000:3000'
+    environment:
+      - NEXT_TELEMETRY_DISABLED=1
+    command: npm run dev
+
+  listing_context:
+    build: ./backend/listing_context
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/postgres
+    depends_on:
+      - db
+    ports:
+      - '8000:8000'
+
+  scanner_context:
+    build: ./backend/scanner_context
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/postgres
+      - LISTING_CONTEXT_URL=http://listing_context:8000
+    depends_on:
+      - listing_context
+      - db
+    ports:
+      - '8001:8001'
+
+  dmca_context:
+    build: ./backend/dmca_context
+    environment:
+      - LISTING_CONTEXT_URL=http://listing_context:8000
+    depends_on:
+      - listing_context
+    ports:
+      - '8002:8002'
+
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - '5432:5432'
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+volumes:
+  db-data:

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "claimbot-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "tailwindcss": "latest",
+    "autoprefixer": "latest",
+    "postcss": "latest",
+    "typescript": "latest"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,16 @@
+import ListingCard from '../../components/ListingCard';
+
+const mockListings = [
+  { id: 1, title: 'Sample Item 1', imageUrl: '/placeholder.png', similarity: 0.92 },
+  { id: 2, title: 'Sample Item 2', imageUrl: '/placeholder.png', similarity: 0.88 },
+];
+
+export default function Dashboard() {
+  return (
+    <main className="p-4 grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+      {mockListings.map((listing) => (
+        <ListingCard key={listing.id} listing={listing} />
+      ))}
+    </main>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-100 text-gray-900;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,12 @@
+import '../app/globals.css';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="flex items-center justify-center h-screen">
+      <h1 className="text-2xl font-bold">ClaimBot</h1>
+    </main>
+  );
+}

--- a/frontend/src/app/submit/page.tsx
+++ b/frontend/src/app/submit/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+import { useState } from 'react';
+
+export default function Submit() {
+  const [form, setForm] = useState({ shopUrl: '', title: '', description: '', imageUrl: '' });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // TODO: submit to backend
+    alert('Submitted');
+  };
+
+  return (
+    <main className="p-4 max-w-xl mx-auto">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input name="shopUrl" placeholder="Shop URL" className="w-full p-2 rounded border" onChange={handleChange} />
+        <input name="title" placeholder="Title" className="w-full p-2 rounded border" onChange={handleChange} />
+        <textarea name="description" placeholder="Description" className="w-full p-2 rounded border" onChange={handleChange} />
+        <input name="imageUrl" placeholder="Image URL" className="w-full p-2 rounded border" onChange={handleChange} />
+        <button type="submit" className="px-4 py-2 bg-black text-white rounded">Submit</button>
+      </form>
+    </main>
+  );
+}

--- a/frontend/src/components/ListingCard.tsx
+++ b/frontend/src/components/ListingCard.tsx
@@ -1,0 +1,10 @@
+export default function ListingCard({ listing }: { listing: { id: number; title: string; imageUrl: string; similarity: number } }) {
+  return (
+    <div className="bg-white rounded shadow p-4 hover:shadow-lg transition-transform hover:scale-105">
+      <img src={listing.imageUrl} alt={listing.title} className="w-full h-48 object-cover rounded" />
+      <h2 className="mt-2 font-semibold">{listing.title}</h2>
+      <span className="text-sm text-gray-600">Similarity: {(listing.similarity * 100).toFixed(0)}%</span>
+      <button className="mt-2 px-3 py-1 bg-blue-600 text-white rounded">Generate DMCA</button>
+    </div>
+  );
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,26 @@
+import argparse
+import requests
+import os
+
+SCANNER_URL = os.getenv('SCANNER_CONTEXT_URL', 'http://scanner_context:8001')
+DMCA_URL = os.getenv('DMCA_CONTEXT_URL', 'http://dmca_context:8002')
+
+parser = argparse.ArgumentParser(description='ClaimBot Orchestrator')
+parser.add_argument('--shop-url', required=True)
+parser.add_argument('--auto-generate', action='store_true')
+parser.add_argument('--output-dir', default='dmca_notices')
+args = parser.parse_args()
+
+resp = requests.post(f'{SCANNER_URL}/scan', json={'shop_url': args.shop_url})
+violations = resp.json().get('violations', [])
+print(f'Found {len(violations)} possible violations')
+
+if args.auto_generate:
+    os.makedirs(args.output_dir, exist_ok=True)
+    for v in violations:
+        r = requests.post(f'{DMCA_URL}/generate', json={'violation_id': v.get('id', 'unknown')})
+        notice = r.json().get('notice', '')
+        filename = os.path.join(args.output_dir, f"{v.get('id','violation')}.md")
+        with open(filename, 'w') as f:
+            f.write(notice)
+        print(f'Generated notice for {v.get("id")}')


### PR DESCRIPTION
## Summary
- bootstrap frontend with Next.js, Tailwind and sample pages
- add FastAPI services for ListingContext, ScannerContext and DMCAContext
- implement a simple CLI orchestrator
- provide Docker Compose setup and example env file

## Testing
- `python -m py_compile orchestrator.py backend/*/app/*.py`

------
https://chatgpt.com/codex/tasks/task_b_687458ea845c833189ae15009a63ccb5